### PR TITLE
Create auto paste wp to chat.ahk

### DIFF
--- a/auto paste wp to chat.ahk
+++ b/auto paste wp to chat.ahk
@@ -1,0 +1,26 @@
+SetTitleMatchMode, 3
+#InstallKeybdHook
+#UseHook
+#InstallMouseHook
+#MenuMaskKey, vkFF
+#IfWinActive, Guild Wars 2 ahk_class ArenaNet_Dx_Window_Class
+#NoEnv
+#Persistent
+onClipBoardChange("ClipChanged")
+
+
+ClipChanged() {
+	SetKeyDelay, 30, 30
+	UniqueID := WinActive("ahk_class ArenaNet_Dx_Window_Class")
+	if (RegExMatch(Clipboard, "\[&........\]") > 0) {
+		
+		if (UniqueID) {
+			Send, {enter}^v{enter}
+		}
+		
+		else {
+			ControlSend, ,{enter}^v{enter}, Guild Wars 2 ahk_class ArenaNet_Dx_Window_Class
+			WinActivate, Guild Wars 2 ahk_class ArenaNet_Dx_Window_Class
+		}
+	}
+}


### PR DESCRIPTION
A script I've been using with Autohotkey that will register if a WP (or any in-game code really) has been copied to the clipboard and paste it to chat. Makes the maprunning experience a lot better since the code from a node that was consumed automatically gets put into chat.